### PR TITLE
Restructure auditor site scraper

### DIFF
--- a/auditor.py
+++ b/auditor.py
@@ -114,7 +114,7 @@ def get_summary(session_requests):
 def get_tax_info(session_requests):
     global CURRENT_RECORD
 
-    tax_request = session_requests.get("http://property.franklincountyauditor.com/_web/datalets/datalet.aspx?mode=taxdistribution&sIndex=0&idx=1&LMparent=20")
+    tax_request = session_requests.get(TAX_URL)
     # file = open("tax.html", "w")
     # file.write(tax_request.text)
     # file.close()

--- a/auditor.py
+++ b/auditor.py
@@ -15,6 +15,7 @@ load_dotenv()
 RUNNING = 1
 CURRENT_RECORD = "not set yet"
 SEARCH_FORM_URL = "http://property.franklincountyauditor.com/_web/search/commonsearch.aspx?mode=parid"
+TAX_URL = "http://property.franklincountyauditor.com/_web/datalets/datalet.aspx?mode=taxdistribution&sIndex=0&idx=1&LMparent=20"
 
 def main():
     global CURRENT_RECORD
@@ -23,8 +24,10 @@ def main():
     RUNNING = get_next_record()
     while RUNNING is 1:
         try:
-            summary_soup = get_summary(CURRENT_RECORD)
-            tax_soup = 0
+            # Create a persistent session
+            session_requests = requests.session()
+            summary_soup = get_summary(session_requests)
+            tax_soup = get_tax_info(session_requests)
             data = {
                 "parcel_id"              : get_parcel_id(summary_soup),
                 "address"                : get_address(summary_soup),
@@ -86,9 +89,8 @@ def get_next_record():
 
 
 
-def get_summary(CURRENT_RECORD):
-    # Create a persistent session
-    session_requests = requests.session()
+def get_summary(session_requests):
+    global CURRENT_RECORD
 
     # Retrieve the search form
     search_form_request = session_requests.get(SEARCH_FORM_URL)
@@ -106,6 +108,17 @@ def get_summary(CURRENT_RECORD):
     }
     results_request = session_requests.post(SEARCH_FORM_URL, search_form_parameters)
     return BeautifulSoup(results_request.content, 'html.parser')
+
+
+
+def get_tax_info(session_requests):
+    global CURRENT_RECORD
+
+    tax_request = session_requests.get("http://property.franklincountyauditor.com/_web/datalets/datalet.aspx?mode=taxdistribution&sIndex=0&idx=1&LMparent=20")
+    # file = open("tax.html", "w")
+    # file.write(tax_request.text)
+    # file.close()
+    return BeautifulSoup(tax_request.content, 'html.parser')
 
 
 

--- a/auditor.py
+++ b/auditor.py
@@ -133,10 +133,62 @@ def store_data(data):
         database=os.getenv("MYSQL_DATABASE")
     )
     cursor = db.cursor()
-    print("Storing scraped data")
-    sql = "UPDATE `tax_info` SET `status` = 1 WHERE `parcel_id` = '" + str(CURRENT_RECORD) + "' LIMIT 1"
-    val = ( CURRENT_RECORD )
-    cursor.execute(sql)
+    sql = """
+        UPDATE `tax_info`
+        SET
+            `status` = 1,
+            `address` = %s,
+            `ts_zip_code` = %s,
+            `company_name` = %s,
+            `tbm_name_1` = %s,
+            `tbm_name_2` = %s,
+            `tbm_address` = %s,
+            `tbm_city_state_zip` = %s,
+            `ts_tax_district` = %s,
+            `ts_school_district` = %s,
+            `ts_rental_registration` = %s,
+            `ts_tax_lien` = %s,
+            `dd_year_built` = %s,
+            `dd_fin_area` = %s,
+            `dd_bedrooms` = %s,
+            `dd_full_baths` = %s,
+            `dd_half_baths` = %s,
+            `sd_acres` = %s,
+            `mrt_tansfer_date` = %s,
+            `mrt_transfer_price` = %s,
+            `property_class` = %s,
+            `land_use` = %s,
+            `net_annual_tax` = %s
+        WHERE
+            (`parcel_id` = %s);
+    """
+    values = (
+                str( data["address"] ),
+                str( data["ts_zip_code"] ),
+                str( data["company_name"] ),
+                str( data["tbm_name_1"] ),
+                str( data["tbm_name_2"] ),
+                str( data["tbm_address"] ),
+                str( data["tbm_city_state_zip"] ),
+                str( data["ts_tax_district"] ),
+                str( data["ts_school_district"] ),
+                str( data["ts_rental_registration"] ),
+                str( data["ts_tax_lien"] ),
+                str( data["dd_year_built"] ),
+                str( data["dd_fin_area"] ),
+                str( data["dd_bedrooms"] ),
+                str( data["dd_full_baths"] ),
+                str( data["dd_half_baths"] ),
+                str( data["sd_acres"] ),
+                str( data["mrt_tansfer_date"] ),
+                str( data["mrt_transfer_price"] ),
+                str( data["property_class"] ),
+                str( data["land_use"] ),
+                str( data["net_annual_tax"] ),
+                str(CURRENT_RECORD)
+    )
+
+    cursor.execute(sql, values)
     db.commit()
 
 

--- a/auditor.py
+++ b/auditor.py
@@ -52,7 +52,10 @@ def main():
                 "mrt_transfer_price"     : get_mrt_transfer_price(summary_soup),
                 "property_class"         : get_property_class(tax_soup),
                 "land_use"               : get_land_use(tax_soup),
-                "net_annual_tax"         : get_net_annual_tax(tax_soup)
+                "net_annual_tax"         : get_net_annual_tax(tax_soup),
+                "tyd_annual_total"       : get_tyd_annual_total(tax_soup),
+                "tyd_payment_total"      : get_tyd_payment_total(tax_soup),
+                "tyd_total_total"        : get_tyd_total_total(tax_soup)
             }
             store_data(data)
         except:
@@ -156,7 +159,10 @@ def store_data(data):
             `mrt_transfer_price` = %s,
             `property_class` = %s,
             `land_use` = %s,
-            `net_annual_tax` = %s
+            `net_annual_tax` = %s,
+            `tyd_annual_total` = %s,
+            `tyd_payment_total` = %s,
+            `tyd_total_total` = %s
         WHERE
             (`parcel_id` = %s);
     """
@@ -183,6 +189,9 @@ def store_data(data):
                 str( data["property_class"] ),
                 str( data["land_use"] ),
                 str( data["net_annual_tax"] ),
+                str( data["tyd_annual_total"] ),
+                str( data["tyd_payment_total"] ),
+                str( data["tyd_total_total"] ),
                 str(CURRENT_RECORD)
     )
 
@@ -351,6 +360,19 @@ def get_net_annual_tax(soup):
     return soup.find('table', {'id': 'Tax Status'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
 
 
+
+def get_tyd_annual_total(soup):
+    return soup.find('table', {'id': 'Tax Year Detail'}).findChildren('td', {'class': 'DataletData'})[61].contents[0]
+
+
+
+def get_tyd_payment_total(soup):
+    return soup.find('table', {'id': 'Tax Year Detail'}).findChildren('td', {'class': 'DataletData'})[63].contents[0]
+
+
+
+def get_tyd_total_total(soup):
+    return soup.find('table', {'id': 'Tax Year Detail'}).findChildren('td', {'class': 'DataletData'})[64].contents[0]
 
 
 

--- a/auditor.py
+++ b/auditor.py
@@ -340,17 +340,18 @@ def get_mrt_transfer_price(soup):
 
 
 def get_property_class(soup):
-    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[0].contents[0]
+    return soup.find('table', {'id': 'Tax Status'}).findChildren('td', {'class': 'DataletData'})[0].contents[0]
 
 
 
 def get_land_use(soup):
-    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[1].contents[0]
+    return soup.find('table', {'id': 'Tax Status'}).findChildren('td', {'class': 'DataletData'})[1].contents[0]
 
 
 
 def get_net_annual_tax(soup):
-    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
+    return soup.find('table', {'id': 'Tax Status'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
+
 
 
 

--- a/auditor.py
+++ b/auditor.py
@@ -15,7 +15,7 @@ load_dotenv()
 RUNNING = 1
 CURRENT_RECORD = "not set yet"
 SEARCH_FORM_URL = "http://property.franklincountyauditor.com/_web/search/commonsearch.aspx?mode=parid"
-TAX_URL = "http://property.franklincountyauditor.com/_web/datalets/datalet.aspx?mode=taxdistribution&sIndex=0&idx=1&LMparent=20"
+TAX_URL = "http://property.franklincountyauditor.com/_web/datalets/datalet.aspx?mode=taxpayments&sIndex=7&idx=1&LMparent=20"
 
 def main():
     global CURRENT_RECORD

--- a/auditor.py
+++ b/auditor.py
@@ -82,7 +82,6 @@ def get_next_record():
     result = cursor.fetchone()
     if cursor.rowcount is 1:
         CURRENT_RECORD = str( result[0] )
-        print("got next record: " + CURRENT_RECORD)
         return 1
     else:
         print("Could not find any more records")

--- a/auditor.py
+++ b/auditor.py
@@ -37,8 +37,8 @@ def main():
                 "tbm_name_2"             : get_tbm_name_2(summary_soup),
                 "tbm_address"            : get_tbm_address(summary_soup),
                 "tbm_city_state_zip"     : get_tbm_city_state_zip(summary_soup),
-                "ts_address_1"           : get_ts_address_1(summary_soup),
-                "ts_address_2"           : get_ts_address_2(summary_soup),
+                "ts_tax_district"        : get_ts_tax_district(summary_soup),
+                "ts_school_district"     : get_ts_school_district(summary_soup),
                 "ts_rental_registration" : get_ts_rental_registration(summary_soup),
                 "ts_tax_lien"            : get_ts_tax_lien(summary_soup),
                 "dd_year_built"          : get_dd_year_built(summary_soup),
@@ -168,117 +168,137 @@ def get_status(soup):
 
 
 def get_parcel_id(soup):
-    return 'NULL'
+    return CURRENT_RECORD
 
 
 
 def get_address(soup):
-    return 'NULL'
+    return soup.find('tr', {'id': 'datalet_header_row'}).findChildren('td', {'class': 'DataletHeaderBottom'})[1].contents[0]
 
 
 
 def get_ts_zip_code(soup):
-    return 'NULL'
+    return soup.find('table', {'id': '2017 Tax Status'}).findChildren('td', {'class': 'DataletData'})[13].contents[0]
 
 
 
 def get_company_name(soup):
-    return 'NULL'
+    return ''
 
 
 
 def get_tbm_name_1(soup):
-    return 'NULL'
+    name = soup.find('table', {'id': 'Owner'}).findChildren('td', {'class': 'DataletData'})[11].contents[0]
+    return name.replace(u'\xa0', '')
 
 
 
 def get_tbm_name_2(soup):
-    return 'NULL'
+    name = soup.find('table', {'id': 'Owner'}).findChildren('td', {'class': 'DataletData'})[12].contents[0]
+    return name.replace(u'\xa0', '')
 
 
 
 def get_tbm_address(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Owner'}).findChildren('td', {'class': 'DataletData'})[13].contents[0]
 
 
 
 def get_tbm_city_state_zip(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Owner'}).findChildren('td', {'class': 'DataletData'})[14].contents[0]
 
 
 
-def get_ts_address_1(soup):
-    return 'NULL'
+def get_ts_tax_district(soup):
+    return soup.find('table', {'id': '2017 Tax Status'}).findChildren('td', {'class': 'DataletData'})[2].contents[0]
 
 
 
-def get_ts_address_2(soup):
-    return 'NULL'
+def get_ts_school_district(soup):
+    return soup.find('table', {'id': '2017 Tax Status'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
 
 
 
 def get_ts_rental_registration(soup):
-    return 'NULL'
+    return soup.find('table', {'id': '2017 Tax Status'}).findChildren('td', {'class': 'DataletData'})[11].contents[0]
 
 
 
 def get_ts_tax_lien(soup):
-    return 'NULL'
+    return soup.find('table', {'id': '2017 Tax Status'}).findChildren('td', {'class': 'DataletData'})[7].contents[0]
 
 
 
 def get_dd_year_built(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Dwelling Data'}):
+        return soup.find('table', {'id': 'Dwelling Data'}).findChildren('td', {'class': 'DataletData'})[0].contents[0]
+    else:
+        return ''
 
 
 
 def get_dd_fin_area(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Dwelling Data'}):
+        return soup.find('table', {'id': 'Dwelling Data'}).findChildren('td', {'class': 'DataletData'})[1].contents[0]
+    else:
+        return ''
 
 
 
 def get_dd_bedrooms(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Dwelling Data'}):
+        return soup.find('table', {'id': 'Dwelling Data'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
+    else:
+        return ''
 
 
 
 def get_dd_full_baths(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Dwelling Data'}):
+        return soup.find('table', {'id': 'Dwelling Data'}).findChildren('td', {'class': 'DataletData'})[4].contents[0]
+    else:
+        return ''
 
 
 
 def get_dd_half_baths(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Dwelling Data'}):
+        return soup.find('table', {'id': 'Dwelling Data'}).findChildren('td', {'class': 'DataletData'})[4].contents[0]
+    else:
+        return ''
 
 
 
 def get_sd_acres(soup):
-    return 'NULL'
+    if soup.find('table', {'id': 'Site Data'}):
+        return soup.find('table', {'id': 'Site Data'}).findChildren('td', {'class': 'DataletData'})[2].contents[0]
+    else:
+        return soup.find('table', {'id': 'Owner'}).findChildren('td', {'class': 'DataletData'})[8].contents[0]
 
 
 
 def get_mrt_tansfer_date(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Most Recent Transfer'}).findChildren('td', {'class': 'DataletData'})[0].contents[0]
 
 
 
 def get_mrt_transfer_price(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Most Recent Transfer'}).findChildren('td', {'class': 'DataletData'})[1].contents[0]
 
 
 
 def get_property_class(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[0].contents[0]
 
 
 
 def get_land_use(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[1].contents[0]
 
 
 
 def get_net_annual_tax(soup):
-    return 'NULL'
+    return soup.find('table', {'id': 'Tax Distribution'}).findChildren('td', {'class': 'DataletData'})[3].contents[0]
 
 
 


### PR DESCRIPTION
This will effectively rewrite `auditor.py` and change how it addresses Parcel IDs. It will now ignore all data except the Parcel ID and all other information will come from the auditor's site.

It will select one ID at a time where the status is 0, scrape information about it, store that information, and then loop back to selecting an ID. When the select returns 0 results the script will stop.